### PR TITLE
Update setup.cfg to be compliant with setuptools v78.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.rst
+description_file = README.rst


### PR DESCRIPTION
[Version 78.0.0](https://setuptools.pypa.io/en/stable/history.html#v78-0-0) of `setuptools` no longer support dash in keys. Keys should use underscore instead (there has been a deprecation warning since 3 Mar 2021).

Keys with dashes fail like this:
```
setuptools.errors.InvalidConfigError: Invalid dash-separated key 'description-file' in 'metadata' (setup.cfg),
please use the underscore name  'description_file' instead.
```

Though the `setuptools` change was rolled in [v78.0.2](https://setuptools.pypa.io/en/stable/history.html#v78-0-2) one day later, it will be reintroduced in 2026, so this patch will make `django-pkgconf` compliant.